### PR TITLE
fix: allow api, ui, store run under same host

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -35,10 +35,10 @@ Create chart name and version as used by the chart label.
 Create urls for api
 */}}
 {{- define "api.uri" -}}
-{{- if .Values.tls.enabled -}}
-{{- printf "https://%s" .Values.api.host -}}
+{{- if .Values.ingress.tls -}}
+{{- printf "https://%s%s" .Values.ingress.hosts.api .Values.ingress.singleHost.apiPath -}}
 {{- else -}}
-{{- printf "http://%s" .Values.api.host -}}
+{{- printf "http://%s%s" .Values.ingress.hosts.api .Values.ingress.singleHost.apiPath -}}
 {{- end -}}
 {{- end -}}
 
@@ -46,10 +46,10 @@ Create urls for api
 Create urls for ui
 */}}
 {{- define "ui.uri" -}}
-{{- if .Values.tls.enabled -}}
-{{- printf "https://%s" .Values.ui.host -}}
+{{- if .Values.ingress.tls -}}
+{{- printf "https://%s%s" .Values.ingress.hosts.ui .Values.ingress.singleHost.uiPath -}}
 {{- else -}}
-{{- printf "http://%s" .Values.ui.host -}}
+{{- printf "http://%s%s" .Values.ingress.hosts.ui .Values.ingress.singleHost.uiPath -}}
 {{- end -}}
 {{- end -}}
 
@@ -57,10 +57,10 @@ Create urls for ui
 Create urls for store
 */}}
 {{- define "store.uri" -}}
-{{- if .Values.tls.enabled -}}
-{{- printf "https://%s" .Values.store.host -}}
+{{- if .Values.ingress.tls -}}
+{{- printf "https://%s%s" .Values.ingress.hosts.store .Values.ingress.singleHost.storePath -}}
 {{- else -}}
-{{- printf "http://%s" .Values.store.host -}}
+{{- printf "http://%s%s" .Values.ingress.hosts.store .Values.ingress.singleHost.storePath -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.tls.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -7,69 +6,64 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: {{ .Values.ui.host }}
+  {{- if .Values.ingress.singleHost.enabled }}
+  - host: {{ .Values.ingress.hosts.ui }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Values.env }}-sdui
+          servicePort: 80
+        path: {{ .Values.ingress.singleHost.uiPath }}
+      - backend:
+          serviceName: {{ .Values.env }}-sdapi
+          servicePort: 80
+        path: {{ .Values.ingress.singleHost.apiPath }}
+      - backend:
+          serviceName: {{ .Values.env }}-sdstore
+          servicePort: 80
+        path: {{ .Values.ingress.singleHost.storePath }}
+  {{- else }}
+  - host: {{ .Values.ingress.hosts.ui }}
     http:
       paths:
       - backend:
           serviceName: {{ .Values.env }}-sdui
           servicePort: 80
         path: /
-  - host: {{ .Values.api.host }}
+  - host: {{ .Values.ingress.hosts.api }}
     http:
       paths:
       - backend:
           serviceName: {{ .Values.env }}-sdapi
           servicePort: 80
         path: /
-  - host: {{ .Values.store.host }}
+  - host: {{ .Values.ingress.hosts.store }}
     http:
       paths:
       - backend:
           serviceName: {{ .Values.env }}-sdstore
           servicePort: 80
         path: /
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
+  {{- if .Values.ingress.singleHost.enabled }}
   - hosts:
-    - {{ .Values.ui.host }}
+    - {{ .Values.ingress.hosts.ui }}
+    secretName: screwdriver-ui-tls
+  {{- else }}
+  - hosts:
+    - {{ .Values.ingress.hosts.ui }}
     secretName: screwdriver-ui-tls
   - hosts:
-    - {{ .Values.api.host }}
+    - {{ .Values.ingress.hosts.api }}
     secretName: screwdriver-api-tls
   - hosts:
-    - {{ .Values.store.host }}
+    - {{ .Values.ingress.hosts.store }}
     secretName: screwdriver-store-tls
-{{- else }}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: ingress
-  namespace: {{ .Values.namespace }}
-  annotations:
-    kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: "nginx"
-spec:
-  rules:
-  - host: {{ .Values.ui.host }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Values.env }}-sdui
-          servicePort: 80
-  - host: {{ .Values.api.host }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Values.env }}-sdapi
-          servicePort: 80
-  - host: {{ .Values.store.host }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Values.env }}-sdstore
-          servicePort: 80
+  {{- end }}
 {{- end }}

--- a/templates/ui.yaml
+++ b/templates/ui.yaml
@@ -51,6 +51,10 @@ spec:
         ports:
         - containerPort: 80
         env:
+          {{- if .Values.ingress.singleHost.enabled }}
+          - name: ROOT_URL
+            value: {{ .Values.ingress.singleHost.uiPath }}
+          {{- end }}
           - name: AVATAR_HOSTNAME
             value: "{{ .Values.ui.avatarHost }}"
           - name: ECOSYSTEM_API

--- a/values.yaml
+++ b/values.yaml
@@ -9,10 +9,24 @@ env: prod
 rbac:
   enabled: false
 
-# Use tls or not, if set to true, please refer to ingress.yaml and create tls secrets accordingly
-# Reference: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-tls:
-  enabled: false
+ingress:
+  # Use tls or not, if set to true, please refer to ingress.yaml and create tls secrets accordingly
+  # Reference: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  tls: false
+  hosts:
+    api: test-api.screwdriver.cd
+    ui: test-cd.screwdriver.cd
+    store: test-store.screwdriver.cd
+  # Enabled singleHost if your api, store, ui are sharing the same host with different path
+  singleHost:
+    enabled: false
+    # Same host with different path example
+    # apiPath: /api
+    # uiPath: /ui
+    # storePath: /store
+    apiPath: ""
+    uiPath: ""
+    storePath: ""
 
 # Set up build notifications or not, if yes please add notification config in your screwdirver-api-secret file
 # Reference config: https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml#L235
@@ -21,11 +35,9 @@ notifications:
 
 api:
   image: screwdrivercd/screwdriver:v0.5.475
-  host: test-api.screwdriver.cd
 
 ui:
-  image: screwdrivercd/ui:v1.0.337
-  host: test-cd.screwdriver.cd
+  image: screwdrivercd/ui:v1.0.338
   avatarHost: "*.githubusercontent.com"
 
 store:
@@ -44,7 +56,7 @@ launcher:
 
 # Enable queue feature or not, this will bring up a queue-worker pod and a redis pod
 queue:
-  enabled: true
+  enabled: false
   image: screwdrivercd/queue-worker:v2.2.3
 
 redis:
@@ -52,6 +64,8 @@ redis:
     enabled: false
   master:
     persistence:
+      # To specify non-default storageClass, uncomment the line below and set it accordingly
+      # storageClass: "enc-gp2"
       enabled: true
       size: 10Gi
 
@@ -76,5 +90,7 @@ postgresql:
   service:
     port: 5432
   persistence:
+    # To specify non-default storageClass, uncomment the line below and set it accordingly
+    # storageClass: "enc-gp2"
     enabled: true
     size: 20Gi


### PR DESCRIPTION
allow api, ui, store to run under same host with different path

`Blocked by`: https://github.com/screwdriver-cd/ui/pull/367