### PR TITLE
fix: pull in new images (#4)

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create urls for api
 */}}
 {{- define "api.uri" -}}
-{{- if .Values.ingress.tls -}}
+{{- if .Values.https -}}
 {{- printf "https://%s%s" .Values.ingress.hosts.api .Values.ingress.singleHost.apiPath -}}
 {{- else -}}
 {{- printf "http://%s%s" .Values.ingress.hosts.api .Values.ingress.singleHost.apiPath -}}
@@ -46,7 +46,7 @@ Create urls for api
 Create urls for ui
 */}}
 {{- define "ui.uri" -}}
-{{- if .Values.ingress.tls -}}
+{{- if .Values.https -}}
 {{- printf "https://%s%s" .Values.ingress.hosts.ui .Values.ingress.singleHost.uiPath -}}
 {{- else -}}
 {{- printf "http://%s%s" .Values.ingress.hosts.ui .Values.ingress.singleHost.uiPath -}}
@@ -57,7 +57,7 @@ Create urls for ui
 Create urls for store
 */}}
 {{- define "store.uri" -}}
-{{- if .Values.ingress.tls -}}
+{{- if .Values.https -}}
 {{- printf "https://%s%s" .Values.ingress.hosts.store .Values.ingress.singleHost.storePath -}}
 {{- else -}}
 {{- printf "http://%s%s" .Values.ingress.hosts.store .Values.ingress.singleHost.storePath -}}

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,8 @@
 
 namespace: test-screwdriver
 env: prod
+# Set it to true if your apps are running with https protocol
+https: false
 
 # Please enable it for RBAC enabled k8s cluster
 rbac:
@@ -21,6 +23,13 @@ ingress:
   # Use tls or not, if set to true, please refer to ingress.yaml and create tls secrets accordingly
   # Reference: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   tls: false
+  annotations:
+    # Override these annotations based on your load balancer configurations
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/tls-acme: "true"
+  # This property allows for reports up to a certain size to be uploaded to SonarQube
+  # nginx.ingress.kubernetes.io/proxy-body-size: "8m"
   hosts:
     api: test-api.screwdriver.cd
     ui: test-cd.screwdriver.cd


### PR DESCRIPTION
- Separate tls and https config since user may not need to create tls rules for the ingress, it can come from the upstream.
- Make annotations for ingress configurable at values.yaml