### PR TITLE
fix: Updating all versions of Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This chart bootstraps the whole screwdriver ecosystem and also nginx ingress con
 ## Prerequisites
 
 - Kubernetes 1.6+
-- Helm
+- [Helm](https://github.com/helm/helm)
 - [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). We recommend using [nginx-ingress-controller](https://kubernetes.github.io/ingress-nginx/deploy/) if you don't have any ingress controller pre-installed.
 
 ## Installing the chart:
@@ -21,11 +21,11 @@ An example secret template file `screwdriver-api-secrets.tmpl` is provided. Run 
 $ bash generate_secrets.sh
 # replace name and namespace with what you specify in values.yaml
 $ kubectl apply -f screwdriver-api-secrets.yaml
-# OPTIONAL: create the secrets for store if you configure to use s3 for store
+# OPTIONAL: create the secrets for store if you configure to use S3 for store
 $ kubectl apply -f screwdriver-store-secrets.yaml
 ```
 
-You can customize your screwdriver flavor in `values.yaml`, after that, install the chart:
+You can customize your Screwdriver flavor in `values.yaml`, after that, install the chart:
 
 ```bash
 $ helm dependency update

--- a/values.yaml
+++ b/values.yaml
@@ -49,16 +49,16 @@ notifications:
   enabled: false
 
 api:
-  image: screwdrivercd/screwdriver:v0.5.486
+  image: screwdrivercd/screwdriver:v0.5.722
   replicas: 1
 
 ui:
-  image: screwdrivercd/ui:v1.0.344
+  image: screwdrivercd/ui:v1.0.440
   avatarHost: "*.githubusercontent.com"
   replicas: 1
 
 store:
-  image: screwdrivercd/store:v3.3.5
+  image: screwdrivercd/store:v3.9.0
   replicas: 1
   # if s3 is not enabled, will use pod's memory to store logs, artifacts and that't non-persistent
   s3:
@@ -69,12 +69,12 @@ store:
 
 launcher:
   image: screwdrivercd/launcher
-  version: v5.0.30
+  version: v6.0.12
 
 # Enable queue feature or not, this will bring up a queue-worker pod and a redis pod
 queue:
   enabled: false
-  image: screwdrivercd/queue-worker:v2.2.3
+  image: screwdrivercd/queue-worker:v2.7.9
 
 # Queue for screwdriver
 # Please refer to https://github.com/helm/charts/tree/master/stable/redis for more configurations


### PR DESCRIPTION
## Context

Docker images are outdated

## References

https://github.com/screwdriver-cd/screwdriver/releases
https://github.com/screwdriver-cd/launcher/releases
https://github.com/screwdriver-cd/store/releases
https://github.com/screwdriver-cd/ui/releases
https://github.com/screwdriver-cd/queue-worker/releases

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
