### PR TITLE
fix: Add queue resource config options

### DIFF
--- a/templates/queue-worker.yaml
+++ b/templates/queue-worker.yaml
@@ -50,6 +50,24 @@ spec:
             value: {{ template "api.uri" . }}
           - name: ECOSYSTEM_STORE
             value: {{ template "store.uri" . }}
+          - name: K8S_BUILD_TIMEOUT
+            value: {{ .Values.queue.buildTimeout }}
           - name: K8S_MAX_BUILD_TIMEOUT
-            value: "720"
+            value: {{ .Values.queue.maxBuildTimeout }}
+          - name: K8S_CPU_MICRO
+            value: {{ .Values.queue.resources.cpu.micro }}
+          - name: K8S_CPU_LOW
+            value: {{ .Values.queue.resources.cpu.low }}
+          - name: K8S_CPU_HIGH
+            value: {{ .Values.queue.resources.cpu.high }}
+          - name: K8S_CPU_TURBO
+            value: {{ .Values.queue.resources.cpu.turbo }}
+          - name: K8S_MEMORY_MICRO
+            value: {{ .Values.queue.resources.memory.micro }}
+          - name: K8S_MEMORY_LOW
+            value: {{ .Values.queue.resources.memory.low }}
+          - name: K8S_MEMORY_HIGH
+            value: {{ .Values.queue.resources.memory.high }}
+          - name: K8S_MEMORY_TURBO
+            value: {{ .Values.queue.resources.memory.turbo }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -72,9 +72,28 @@ launcher:
   version: v6.0.12
 
 # Enable queue feature or not, this will bring up a queue-worker pod and a redis pod
+# Please refer to https://github.com/screwdriver-cd/queue-worker/blob/master/config/custom-environment-variables.yaml
 queue:
   enabled: false
   image: screwdrivercd/queue-worker:v2.7.9
+  buildTimeout: 90
+  maxBuildTimeout: 720
+  # Resources for build pod
+  resources:
+      # Number of cpu cores
+      # By default, builds run on LOW cpu
+      cpu:
+          micro: "0.5"
+          low: 2
+          high: 6
+          turbo: 12
+      # Memory in GB
+      # By default, builds run on LOW memory
+      memory:
+          micro: 1
+          low: 2
+          high: 12
+          turbo: 16
 
 # Queue for screwdriver
 # Please refer to https://github.com/helm/charts/tree/master/stable/redis for more configurations


### PR DESCRIPTION
## Context

Sometimes users might want to tweak the amount of resources builds consume by default, since builds are run on LOW cpu and memory by default (https://github.com/screwdriver-cd/executor-k8s/blob/master/index.js#L275).

## Objective

This PR adds more queue resource config options.

## References

Related to https://stackoverflow.com/questions/57379819/resources-consumed-by-build-jobs-in-screwdriver-cd

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
