### PR TITLE
Fix quotation mark from double to single

### DIFF
--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -19,10 +19,10 @@ openssl rsa -in jwt.pem -pubout -out jwt.pub
 privatekey=`cat jwt.pem | base64`
 publickey=`cat jwt.pub | base64`
 
-sed -i.bak "s/{{jwtpublickey}}/$publickey/g" screwdriver-api-secrets.yaml
-sed -i.bak "s/{{jwtprivatekey}}/$privatekey/g" screwdriver-api-secrets.yaml
+sed -i.bak 's/{{jwtpublickey}}/$publickey/g' screwdriver-api-secrets.yaml
+sed -i.bak 's/{{jwtprivatekey}}/$privatekey/g' screwdriver-api-secrets.yaml
 
 scmsettings=`cat example-scm-settings.json | base64`
-sed -i.bak "s/{{scmsettings}}/$scmsettings/g" screwdriver-api-secrets.yaml
+sed -i.bak 's/{{scmsettings}}/$scmsettings/g' screwdriver-api-secrets.yaml
 
 rm screwdriver-api-secrets.yaml.bak


### PR DESCRIPTION
## Context

Both GNU sed 4.4 and BSE FreeBSD sed 101.11.1 shows the "unterminated `s' command" error when wrapped with a double quotation.

## Objective

Change quotation marks from double to single to fix the above error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
