### PR TITLE
Remove trailing newline

### DIFF
--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -16,13 +16,13 @@ done
 openssl genrsa -out jwt.pem 2048
 openssl rsa -in jwt.pem -pubout -out jwt.pub
 
-privatekey=`cat jwt.pem | base64`
-publickey=`cat jwt.pub | base64`
+privatekey=`cat jwt.pem | base64 | tr -d '\n'`
+publickey=`cat jwt.pub | base64 | tr -d '\n'`
 
 sed -i.bak "s/{{jwtpublickey}}/$publickey/g" screwdriver-api-secrets.yaml
 sed -i.bak "s/{{jwtprivatekey}}/$privatekey/g" screwdriver-api-secrets.yaml
 
-scmsettings=`cat example-scm-settings.json | base64`
+scmsettings=`cat example-scm-settings.json | base64 | tr -d '\n'`
 sed -i.bak "s/{{scmsettings}}/$scmsettings/g" screwdriver-api-secrets.yaml
 
 rm screwdriver-api-secrets.yaml.bak


### PR DESCRIPTION
#  Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Generated JWT certs have a line break at end of the line. However, the sed(FreeBSD) command shows an "unescaped newline inside substitute pattern" error when receiving a multi-line string. GNU has the same problem.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Remove trailing newline to fix sed error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
