### PR TITLE
fix(1846): bump dependencies and update apiVersion of deploynments

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.10.0
+  version: ^10.5.7
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.3
-digest: sha256:a2e46730065a7c02eb3553a0e65c8df196766c329fdb93579263f5b65109945f
-generated: 2018-10-12T14:50:19.879215339-07:00
+  version: 8.6.4
+digest: sha256:6abe17147f300e4c0ceedcdf6e5dda01ed7082fdd92e754492dde973d66dd2ad
+generated: "2020-05-01T10:19:55.162491+09:00"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  version: "^3.4.1"
+  version: "^10.5.7"
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: queue.enabled
 - name: postgresql
-  version: 0.8.3
+  version: 8.6.4
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -17,7 +17,7 @@ spec:
     tier: app
 ---
 # requires service account to be created
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.env }}-sdapi
@@ -130,12 +130,12 @@ spec:
           - name: DATASTORE_SEQUELIZE_PASSWORD
             valueFrom:
               secretKeyRef:
-                key: postgres-password
+                key: postgresql-password
                 name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} "screwdriver-api-{{ .Values.env }}-secrets" {{- end }}
           - name: DATASTORE_SEQUELIZE_PORT
-            value: {{ .Values.postgresql.postgresPort | quote }}
+            value: {{ .Values.postgresql.postgresqlPort | quote }}
           - name: DATASTORE_SEQUELIZE_USERNAME
-            value: {{ .Values.postgresql.postgresUser | quote }}
+            value: {{ .Values.postgresql.postgresqlUsername | quote }}
           - name: SECRET_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/templates/queue-worker.yaml
+++ b/templates/queue-worker.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.queue.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.env }}-sdworker

--- a/templates/store.yaml
+++ b/templates/store.yaml
@@ -17,7 +17,7 @@ spec:
     env: {{ .Values.env }}
     tier: app
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.env }}-sdstore

--- a/templates/ui.yaml
+++ b/templates/ui.yaml
@@ -17,7 +17,7 @@ spec:
     env: {{ .Values.env }}
 ---
 # requires service account to be created
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.env }}-sdui

--- a/values.yaml
+++ b/values.yaml
@@ -117,9 +117,9 @@ postgresql:
   # 2. set postgressql enabled to false to prevent creation of postgres as a pod
   # 3. uncomment the line below with your externl postgres server
   # postgresServer: ""
-  postgresUser: "sdUser"
-  postgresPassword: "sdPassword"
-  postgresDatabase: "screwdriver"
+  postgresqlUsername: "sdUser"
+  postgresqlPassword: "sdPassword"
+  postgresqlDatabase: "screwdriver"
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432


### PR DESCRIPTION
## Context
This chart doesn't work in latest kubernetes because of apiVersion of deployments. 
All deployments in `screwdriver-chart` are defined with `extensions/v1beta1` apiVersion, but this apiVersion has been removed in latest kubernetes.

## Objective
This updates apiVersion in deployments.
I confirm it works well in my kube1.18 env.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1846
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
