### PR TITLE
feat: add queue svc jwt env variable

### DIFF
--- a/templates/api.yaml
+++ b/templates/api.yaml
@@ -130,6 +130,11 @@ spec:
               secretKeyRef:
                 name: screwdriver-api-secrets
                 key: jwtpublickey
+          - name: SECRET_JWT_QUEUE_SVC_PUBLIC_KEY
+            valueFrom:
+              secretKeyRef:
+                name: screwdriver-api-secrets
+                key: jwtqueuesvcpublickey
           - name: SECRET_COOKIE_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name  }}-{{ template "screwdriver.name" .}}-ingress

--- a/templates/podRoleBinding.yaml
+++ b/templates/podRoleBinding.yaml
@@ -2,7 +2,7 @@
 # Setup sd-build as a reader. This has to be a
 # ClusterRoleBinding to get access to non-resource URLs
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-read
 subjects:
@@ -18,7 +18,7 @@ roleRef:
 
 # Setup sd-build as a writer in its namespace
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-write
 subjects:

--- a/templates/podRoles.yaml
+++ b/templates/podRoles.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.rbac.enabled -}}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Values.namespace }}
   name: pod-writer
@@ -13,7 +13,7 @@ rules:
 ---
 # Full read access to the api and resources
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Values.namespace }}
   name: pod-reader


### PR DESCRIPTION
## Context

Helm chart fails as it is missing an environment variable for jwt auth from queue svc to api

## Objective

This PR adds the missing env var

## References

https://github.com/screwdriver-cd/screwdriver/issues/2244

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
