### PR TITLE
fix: Add jwtqueuesvcpublickey to secrets file

### DIFF
--- a/screwdriver-api-secrets.tmpl
+++ b/screwdriver-api-secrets.tmpl
@@ -7,6 +7,7 @@ type: Opaque
 data:
   jwtpublickey: {{api-jwtpublickey}}
   jwtprivatekey: {{api-jwtprivatekey}}
+  jwtqueuesvcpublickey : {{queue-jwtpublickey}}
   cookiepassword: {{cookiepassword}}
   encryptionpassword: {{encryptionpassword}}
   hashingpassword: {{hashingpassword}}


### PR DESCRIPTION
## Context

When deploying chart, the my-screwdriver-api-XXXX pod fails to instantiate with error couldn't find key jwtqueuesvcpublickey in Secret test-screwdriver/screwdriver-api-secrets.

## Objective

This PR adds the key to the secrets yaml file

## References

https://github.com/screwdriver-cd/screwdriver-chart/issues/22

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
