### PR TITLE
fix: Use ~ as delimiter for sed

### DIFF
--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -9,7 +9,7 @@ cp screwdriver-api-secrets.tmpl screwdriver-api-secrets.yaml
 
 for name in '{{cookiepassword}}' '{{encryptionpassword}}' '{{hashingpassword}}'; do
   value=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 32 | base64)
-  sed -i.bak "s/$name/$value/g" screwdriver-api-secrets.yaml
+  sed -i.bak "s~$name/$value~g" screwdriver-api-secrets.yaml
 done
 
 for target in 'api' 'queue'; do
@@ -19,11 +19,11 @@ for target in 'api' 'queue'; do
   privatekey=$(cat "${target}-jwt.pem" | base64 | tr -d '\n')
   publickey=$(cat "${target}-jwt.pub" | base64 | tr -d '\n')
 
-  sed -i.bak "s~{{${target}-jwtpublickey}}/$publickey/g" screwdriver-api-secrets.yaml
-  sed -i.bak "s~{{${target}-jwtprivatekey}}/$privatekey/g" screwdriver-api-secrets.yaml
+  sed -i.bak "s~{{${target}-jwtpublickey}}/$publickey~g" screwdriver-api-secrets.yaml
+  sed -i.bak "s~{{${target}-jwtprivatekey}}/$privatekey~g" screwdriver-api-secrets.yaml
 done
 
 scmsettings=$(cat example-scm-settings.json | base64 | tr -d '\n')
-sed -i.bak "s/{{scmsettings}}/$scmsettings/g" screwdriver-api-secrets.yaml
+sed -i.bak "s~{{scmsettings}}/$scmsettings~g" screwdriver-api-secrets.yaml
 
 rm screwdriver-api-secrets.yaml.bak

--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -19,8 +19,8 @@ for target in 'api' 'queue'; do
   privatekey=$(cat "${target}-jwt.pem" | base64 | tr -d '\n')
   publickey=$(cat "${target}-jwt.pub" | base64 | tr -d '\n')
 
-  sed -i.bak "s/{{${target}-jwtpublickey}}/$publickey/g" screwdriver-api-secrets.yaml
-  sed -i.bak "s/{{${target}-jwtprivatekey}}/$privatekey/g" screwdriver-api-secrets.yaml
+  sed -i.bak "s~{{${target}-jwtpublickey}}/$publickey/g" screwdriver-api-secrets.yaml
+  sed -i.bak "s~{{${target}-jwtprivatekey}}/$privatekey/g" screwdriver-api-secrets.yaml
 done
 
 scmsettings=$(cat example-scm-settings.json | base64 | tr -d '\n')


### PR DESCRIPTION
## Context

sed: command errors with : bad flag in substitute command: 'Z'  while running generate_secrets.sh

## Objective

This error happens when there is a '/' in the string and the delimiter is /''. This PR replaces delimiter with '~' to fix the error 

## References

https://stackoverflow.com/questions/32610261/sed-error-bad-flag-in-substitute-command-u
https://github.com/screwdriver-cd/screwdriver-chart/issues/21

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
