### PR TITLE
Update ingress to latest API version

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name  }}-{{ template "screwdriver.name" .}}-ingress
@@ -16,39 +16,54 @@ spec:
     http:
       paths:
       - backend:
-          serviceName:  {{ template "ui.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "ui.fullname" . }}
+            port:
+              number: 80
         path: {{ .Values.ingress.singleHost.uiPath }}
       - backend:
-          serviceName:  {{ template "api.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "api.fullname" . }}
+            port:
+              number: 80
         path: {{ .Values.ingress.singleHost.apiPath }}
       - backend:
-          serviceName:  {{ template "store.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "store.fullname" . }}
+            port:
+              number: 80
         path: {{ .Values.ingress.singleHost.storePath }}
   {{- else }}
   - host: {{ .Values.ingress.hosts.ui }}
     http:
       paths:
       - backend:
-          serviceName:  {{ template "ui.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "ui.fullname" . }}
+            port:
+              number: 80
         path: /
+        pathType: Prefix
   - host: {{ .Values.ingress.hosts.api }}
     http:
       paths:
       - backend:
-          serviceName:  {{ template "api.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "api.fullname" . }}
+            port:
+              number: 80
         path: /
+        pathType: Prefix
   - host: {{ .Values.ingress.hosts.store }}
     http:
       paths:
       - backend:
-          serviceName:  {{ template "store.fullname" . }}
-          servicePort: 80
+          service:
+            name:  {{ template "store.fullname" . }}
+            port:
+              number: 80
         path: /
+        pathType: Prefix
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
## Context

The `ingress` API was [updated in Kube 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)

## Objective

This allows the `helm` chart to work on Kube clusters running 1.22 and later.

## References

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
